### PR TITLE
1220935 - fix module-retailer - compatibility Magento 2.4.6 and PHP8.2

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,66 @@
+name: 'Static Analysis'
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  static-analysis:
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.1'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
+
+      - name: 'Install PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '${{ matrix.php-version }}'
+          coverage: 'none'
+          tools: 'composer:v2'
+        env:
+          COMPOSER_AUTH_JSON: |
+            {
+                "http-basic": {
+                    "repo.magento.com": {
+                        "username": "${{ secrets.MAGENTO_USERNAME }}",
+                        "password": "${{ secrets.MAGENTO_PASSWORD }}"
+                    }
+                }
+            }
+
+      - name: 'Get composer cache directory'
+        id: 'composer-cache'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
+
+      - name: 'Cache dependencies'
+        uses: 'actions/cache@v3'
+        with:
+          path: '${{ steps.composer-cache.outputs.dir }}'
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: '${{ runner.os }}-composer-'
+
+      - name: 'Install dependencies'
+        run: 'composer install --prefer-dist'
+
+      - name: 'Run composer audit'
+        run: 'composer audit --format=plain'
+
+      - name: 'Run Parallel Lint'
+        run: 'vendor/bin/parallel-lint --exclude vendor .'
+
+      - name: 'Run PHP CodeSniffer'
+        run: 'vendor/bin/phpcs --extensions=php,phtml'
+
+      - name: 'Run PHPMD'
+        run: 'vendor/bin/phpmd . xml phpmd.xml.dist'
+
+      - name: 'Run PHPStan'
+        run: 'vendor/bin/phpstan analyse'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 2023-04-12
+
+Dataset compatibility ES 2.11.x and PHP 8.2
+
+- fix Dynamic type declaration
+- fix Type hinting
+- Replace `Zend_Date` by `DateTime`
+- Remove `MutationObserver` support
+- fix UI Component Retailer Offer editing
+- Replace `Zend_Validate` by `Laminas\Validator`
+- fix Retailer Grid Column Action
+- fix Retailer Grid Mass Actions
+- fix some translations
+- remove Temando/Shipping Plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2023-04-12
+## 2023-09-20
 
-Dataset compatibility ES 2.11.x and PHP 8.2
+Dataset compatibility Magento 2.4.6, ES 2.11.x and PHP 8.2
 
-- fix Dynamic type declaration
-- fix Type hinting
+- Fix Dynamic type declaration
+- Fix Type hinting
 - Replace `Zend_Date` by `DateTime`
 - Remove `MutationObserver` support
-- fix UI Component Retailer Offer editing
+- Fix UI Component Retailer Offer editing
 - Replace `Zend_Validate` by `Laminas\Validator`
-- fix Retailer Grid Column Action
-- fix Retailer Grid Mass Actions
-- fix some translations
-- remove Temando/Shipping Plugin
+- Fix Retailer Grid Column Action
+- Fix Retailer Grid Mass Actions
+- Fix some translations
+- Remove Temando/Shipping Plugin

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ If your project is based on Magento 2.1.x you can start working with ElasticSuit
 
 The module requires :
 
-- [ElasticSuite](https://github.com/Smile-SA/elasticsuite) > 2.3.3*
-- [Offer](https://github.com/Smile-SA/magento2-module-offer) > 1.4.*
-- [Seller](https://github.com/Smile-SA/magento2-module-seller) > 1.2.*
-- [Retailer](https://github.com/Smile-SA/magento2-module-retailer) > 1.2.*
+- [ElasticSuite](https://github.com/Smile-SA/elasticsuite) > 2.11.*
+- [Offer](https://github.com/Smile-SA/magento2-module-offer) > 2.1.*
+- [Seller](https://github.com/Smile-SA/magento2-module-seller) > 2.0.*
+- [Retailer](https://github.com/Smile-SA/magento2-module-retailer) > 2.0.*
 - [Store Locator](https://github.com/Smile-SA/magento2-module-store-locator) > 2.0.*
-- [Retailer Offer](https://github.com/Smile-SA/magento2-module-retailer-offer) > 1.7.*
-- [Store Delivery](https://github.com/Smile-SA/magento2-module-store-delivery) > 1.1.*
+- [Retailer Offer](https://github.com/Smile-SA/magento2-module-retailer-offer) > 2.0.*
+- [Store Delivery](https://github.com/Smile-SA/magento2-module-store-delivery) > 2.0.*
 
 It's a toolkit module to install the RetailerSuite modules.
 
@@ -33,6 +33,7 @@ ElasticSuite **2.6.x** |Latest release : ```composer require smile/elasticsuite-
 ElasticSuite **2.7.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~1.5.0"```
 ElasticSuite **2.8.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~1.6.0"```
 ElasticSuite **2.9.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~2.2.0"```
+ElasticSuite **2.11.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~2.3.0"```
 
 2. Enable it
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ If your project is based on Magento 2.1.x you can start working with ElasticSuit
 
 ### Requirements
 
-The module requires :
+The module requires:
 
 - [ElasticSuite](https://github.com/Smile-SA/elasticsuite) > 2.11.*
-- [Offer](https://github.com/Smile-SA/magento2-module-offer) > 2.1.*
+- [Offer](https://github.com/Smile-SA/magento2-module-offer) > 2.0.*
 - [Seller](https://github.com/Smile-SA/magento2-module-seller) > 2.0.*
 - [Retailer](https://github.com/Smile-SA/magento2-module-retailer) > 2.0.*
-- [Store Locator](https://github.com/Smile-SA/magento2-module-store-locator) > 2.0.*
+- [Store Locator](https://github.com/Smile-SA/magento2-module-store-locator) > 2.2.*
 - [Retailer Offer](https://github.com/Smile-SA/magento2-module-retailer-offer) > 2.0.*
 - [Store Delivery](https://github.com/Smile-SA/magento2-module-store-delivery) > 2.0.*
 
@@ -22,20 +22,21 @@ It's a toolkit module to install the RetailerSuite modules.
 
 ### How to use
 
-1. Install the module via Composer :
+1. Install the module via Composer:
 
 
 ElasticSuite Version   | Module Version
 -----------------------|------------------------------------------------------------------------
-ElasticSuite **2.1.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"^1.4"```
-ElasticSuite **2.3.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"^1.4"```
-ElasticSuite **2.6.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"^1.4"```
-ElasticSuite **2.7.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~1.5.0"```
-ElasticSuite **2.8.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~1.6.0"```
-ElasticSuite **2.9.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~2.2.0"```
-ElasticSuite **2.11.x** |Latest release : ```composer require smile/elasticsuite-for-retailer:"~2.3.0"```
+ElasticSuite **2.1.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"^1.4"```
+ElasticSuite **2.3.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"^1.4"```
+ElasticSuite **2.6.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"^1.4"```
+ElasticSuite **2.7.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"~1.5.0"```
+ElasticSuite **2.8.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"~1.6.0"```
+ElasticSuite **2.9.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"~2.2.0"```
+ElasticSuite **2.11.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"~2.3.0"```
+ElasticSuite **2.11.x** |Latest release: ```composer require smile/elasticsuite-for-retailer:"~2.4.0"```
 
-2. Enable it
+2. Enable it:
 
 ``` bin/magento module:enable Smile_Offer ```
 
@@ -49,7 +50,15 @@ ElasticSuite **2.11.x** |Latest release : ```composer require smile/elasticsuite
 
 ``` bin/magento module:enable Smile_StoreDelivery ```
 
-3. Install the module and rebuild the DI cache
+3. Optionnal: Drop old SMILE_RETAILER_ADDRESS_RETAILER_ID unique key
+
+_if you already used older retailersuite modules on your projects, and you want to upgrade it,_
+_before upgrading, you will have to DROP your current UNIQUE KEY from table smile_retailer_address : SMILE_RETAILER_ADDRESS_RETAILER_ID_
+_This is necessary in order to get a db_schema.xml working correctly._
+
+``` ALTER TABLE smile_retailer_address DROP INDEX SMILE_RETAILER_ADDRESS_RETAILER_ID ```
+
+4. Install the module and rebuild the DI cache:
 
 ``` bin/magento setup:upgrade ```
 
@@ -57,10 +66,10 @@ ElasticSuite **2.11.x** |Latest release : ```composer require smile/elasticsuite
 
 > Stores > Configuration > Elasticsuite > Elastic Suite for Retailer
 
-Navigation mode : Retailer/Drive   
-    * Drive mode : the customer will only see the catalog of the chosen retailer in Front Office.    
-    * Retail mode : the customer will browse the Web catalog by default.   
-Display offers on product page : Yes/No (When enabled, offers of all stores will be displayed on product page.)
+Navigation mode: Retailer/Drive   
+    * Drive mode: the customer will only see the catalog of the chosen retailer in Front Office.    
+    * Retail mode: the customer will browse the Web catalog by default.   
+Display offers on product page: Yes/No (When enabled, offers of all stores will be displayed on product page.)
 
 ## What is ElasticSuite for Retailers ?
 
@@ -86,9 +95,10 @@ Together we explore, invent, and test technologies of the future, to better serv
 
 ### Current version
 
-The current **1.4.2** version has been focused on two main features :
+The current **2.4.0** version has been focused on compatibility with Magento 2.4.6:
 
 <br/>
+Some functionnalities example:
 
 * **Store Locator :**
 
@@ -104,16 +114,16 @@ Your customer will be able to choose his favorite shop and this will keep it dur
 
 <br/>
 
-* **Store Offers :**
+* **Store Offers:**
 
-    This features let you create **specific offers for a given product and a given shop** : you'll be able to define the price and/or the availability for a product in each shop.
+    This features let you create **specific offers for a given product and a given shop**: you'll be able to define the price and/or the availability for a product in each shop.
 
 <p align="center">
     <img alt="Offer Step one" src="doc/static/offer-step-one.png" />
     <img alt="Offer Step two" src="doc/static/offer-step-two.png" />
 </p>
 
-   You will be able to enable an option to filter the navigation of the customer to the products available in his favorite shop :
+   You will be able to enable an option to filter the navigation of the customer to the products available in his favorite shop:
 
 <p align="center">
     <img alt="Shop Availability" src="doc/static/shop-availability.png" />
@@ -121,13 +131,13 @@ Your customer will be able to choose his favorite shop and this will keep it dur
 
 <br/>
 
-The customer will even have the possibility to see **product's availability in the other shops** on the product detail page :
+The customer will even have the possibility to see **product's availability in the other shops** on the product detail page:
 
 <p align="center">
     <img alt="Shop Offer List" src="doc/static/shop-offer-list.png" />
 </p>
 
-* **In Store delivery :**
+* **In Store delivery:**
 
     This feature allow the customer to choose between stores for the shipping address of his order.
 
@@ -142,15 +152,15 @@ This is handled during checkout via a Store chooser in a popin.
     <img alt="Store Delivery" src="doc/static/store-delivery-chooser.png" />
 </p>
 
-### And more to come !
+### And more to come!
 
-The next versions that will be coming will include the following features :
+The next versions that will be coming will include the following features:
 
-* **Shops in autocomplete :**
+* **Shops in autocomplete:**
 
     We plan to add the shops to the autocomplete box results for faster access.
 
-* **And many more !**
+* **And many more!**
 
     We will announce and integrate more features to the roadmap soon.
 

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,10 @@
         "smile/module-retailer-service": "Add the ability to add services per retailer",
         "smile/module-retailer-promotion": "Add the ability to add promotion per retailer",
         "smile/module-retailer-admin": "Add the ability to manage ACL in admin panel per retailer"
+    },
+    "config": {
+        "allow-plugins": {
+            "magento/composer-dependency-version-audit-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,17 +30,18 @@
         }
     ],
     "require": {
-        "smile/elasticsuite": "^2.10.4",
+        "php": "^8.1",
+        "magento/framework": ">=103.0.4",
         "magento/magento-composer-installer": "*",
-        "smile/module-offer": "~1.4.0",
-        "smile/module-seller": "~1.2.0",
-        "smile/module-retailer": "~1.2.0",
-        "smile/module-store-locator": "~2.0.0",
-        "smile/module-retailer-offer": "~1.8.0",
-        "smile/module-store-delivery": "~1.1.0"
+        "smile/module-offer": "~2.1.0",
+        "smile/module-seller": "~2.0.0",
+        "smile/module-retailer": "~2.0.0",
+        "smile/module-store-locator": "~2.0",
+        "smile/module-retailer-offer": "~2.0.0",
+        "smile/module-store-delivery": "~2.0.0"
     },
     "require-dev": {
-        "smile/magento2-smilelab-quality-suite": "1.0.0"
+        "smile/magento2-smilelab-quality-suite": "^3.0"
     },
     "suggest": {
         "smile/module-retailer-offer-inventory": "Add inventory management by offers",

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
         "magento/framework": ">=103.0.4",
         "magento/magento-composer-installer": "*",
         "smile/elasticsuite": "^2.11",
-        "smile/module-offer": "~2.1.0",
-        "smile/module-seller": "~2.0.0",
-        "smile/module-retailer": "~2.0.0",
-        "smile/module-store-locator": "~2.0",
-        "smile/module-retailer-offer": "~2.0.0",
-        "smile/module-store-delivery": "~2.0.0"
+        "smile/module-offer": "^2.0",
+        "smile/module-seller": "^2.0",
+        "smile/module-retailer": "^2.0",
+        "smile/module-store-locator": "^2.2",
+        "smile/module-retailer-offer": "^2.0",
+        "smile/module-store-delivery": "^2.0"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -50,10 +50,5 @@
         "smile/module-retailer-service": "Add the ability to add services per retailer",
         "smile/module-retailer-promotion": "Add the ability to add promotion per retailer",
         "smile/module-retailer-admin": "Add the ability to manage ACL in admin panel per retailer"
-    },
-    "config": {
-        "allow-plugins": {
-            "magento/composer-dependency-version-audit-plugin": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "php": "^8.1",
         "magento/framework": ">=103.0.4",
         "magento/magento-composer-installer": "*",
+        "smile/elasticsuite": "^2.11",
         "smile/module-offer": "~2.1.0",
         "smile/module-seller": "~2.0.0",
         "smile/module-retailer": "~2.0.0",


### PR DESCRIPTION
Dataset compatibility ES 2.11.x and PHP 8.2

- fix Dynamic type declaration
- fix Type hinting
- Replace `Zend_Date` by `DateTime`
- Remove `MutationObserver` support
- fix UI Component Retailer Offer editing
- Replace `Zend_Validate` by `Laminas\Validator`
- fix Retailer Grid Column Action
- fix Retailer Grid Mass Actions
- fix some translations
- remove Temando/Shipping Plugin