### PR TITLE
2.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2024-05-03
+
+- Map : Fix geolocalize through header button, see https://github.com/Smile-SA/magento2-module-map/compare/2.1.0...2.1.1
+- Map : Add CSP whitelist
+- Offer : Fix extensionAttribute - Concrete return type must be specified, see https://github.com/Smile-SA/magento2-module-offer/compare/2.0.0...2.0.1
+- Retailer : Fix PSR-0, see https://github.com/Smile-SA/magento2-module-retailer/compare/2.0.0...2.0.1
+- RetailerOffer : Add modal map to product page search, see https://github.com/Smile-SA/magento2-module-retailer-offer/compare/2.0.1...2.0.2
+- RetailerOffer : Fix show product offer price if shop has been selected, even in Retail mode
+- StoreDelivery : Refactor - same search design everywhere, see https://github.com/Smile-SA/magento2-module-store-delivery/compare/2.0.0...2.0.1
+- StoreDelivery : Dont show store delivery shipping method if no markers found
+- StoreLocator : Refactor - same search design everywhere, see https://github.com/Smile-SA/magento2-module-store-locator/compare/2.2.0...2.2.1
+- Update contact form
+
 ## 2023-09-20
 
 Dataset compatibility Magento 2.4.6, ES 2.11.x and PHP 8.2

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,13 @@
         "magento/framework": ">=103.0.4",
         "magento/magento-composer-installer": "*",
         "smile/elasticsuite": "^2.11",
-        "smile/module-offer": "^2.0",
-        "smile/module-seller": "^2.0",
-        "smile/module-retailer": "^2.0",
-        "smile/module-store-locator": "^2.2",
-        "smile/module-retailer-offer": "^2.0",
-        "smile/module-store-delivery": "^2.0"
+        "smile/module-map": "dev-2.1.x",
+        "smile/module-offer": "dev-2.0.x",
+        "smile/module-retailer": "dev-2.0.x",
+        "smile/module-retailer-offer": "dev-2.0.x",
+        "smile/module-seller": "dev-2.0.x",
+        "smile/module-store-delivery": "dev-2.0.x",
+        "smile/module-store-locator": "dev-2.2.x"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,12 @@
         "magento/framework": ">=103.0.4",
         "magento/magento-composer-installer": "*",
         "smile/elasticsuite": "^2.11",
-        "smile/module-map": "2.1.x-dev",
-        "smile/module-offer": "2.0.x-dev",
-        "smile/module-retailer": "2.0.x-dev",
-        "smile/module-retailer-offer": "2.0.x-dev",
-        "smile/module-seller": "2.0.x-dev",
-        "smile/module-store-delivery": "2.0.x-dev",
-        "smile/module-store-locator": "2.2.x-dev"
+        "smile/module-offer": "^2.0",
+        "smile/module-retailer": "^2.0",
+        "smile/module-retailer-offer": "^2.0",
+        "smile/module-seller": "^2.0",
+        "smile/module-store-delivery": "^2.0",
+        "smile/module-store-locator": "^2.2"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,13 @@
         "magento/framework": ">=103.0.4",
         "magento/magento-composer-installer": "*",
         "smile/elasticsuite": "^2.11",
-        "smile/module-map": "dev-2.1.x",
-        "smile/module-offer": "dev-2.0.x",
-        "smile/module-retailer": "dev-2.0.x",
-        "smile/module-retailer-offer": "dev-2.0.x",
-        "smile/module-seller": "dev-2.0.x",
-        "smile/module-store-delivery": "dev-2.0.x",
-        "smile/module-store-locator": "dev-2.2.x"
+        "smile/module-map": "2.1.x-dev",
+        "smile/module-offer": "2.0.x-dev",
+        "smile/module-retailer": "2.0.x-dev",
+        "smile/module-retailer-offer": "2.0.x-dev",
+        "smile/module-seller": "2.0.x-dev",
+        "smile/module-store-delivery": "2.0.x-dev",
+        "smile/module-store-locator": "2.2.x-dev"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "^3.0"


### PR DESCRIPTION
## 2024-05-03

- Map : Fix geolocalize through header button, see https://github.com/Smile-SA/magento2-module-map/compare/2.1.0...2.1.1
- Map : Add CSP whitelist
- Offer : Fix extensionAttribute - Concrete return type must be specified, see https://github.com/Smile-SA/magento2-module-offer/compare/2.0.0...2.0.1
- Retailer : Fix PSR-0, see https://github.com/Smile-SA/magento2-module-retailer/compare/2.0.0...2.0.1
- RetailerOffer : Add modal map to product page search, see https://github.com/Smile-SA/magento2-module-retailer-offer/compare/2.0.1...2.0.2
- RetailerOffer : Fix show product offer price if shop has been selected, even in Retail mode
- StoreDelivery : Refactor - same search design everywhere, see https://github.com/Smile-SA/magento2-module-store-delivery/compare/2.0.0...2.0.1
- StoreDelivery : Dont show store delivery shipping method if no markers found
- StoreLocator : Refactor - same search design everywhere, see https://github.com/Smile-SA/magento2-module-store-locator/compare/2.2.0...2.2.1
- Update contact form